### PR TITLE
Minor improvements to README and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A conditional order is a struct `ConditionalOrderParams`, consisting of:
 
 ##### Single Order
 
-1. Call `ComposableCoW.create` with the `ConditionalOrderParams` struct. Optionally set `dispatch = true` to have events emitted that are picked up by a watch tower.
+1. From the context of the Safe that is placing the order, call `ComposableCoW.create` with the `ConditionalOrderParams` struct. Optionally set `dispatch = true` to have events emitted that are picked up by a watch tower.
 
 ##### Merkle Root
 

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -170,6 +170,7 @@ export const checkForAndPlaceOrder: ActionFn = async (
           console.log("Removing conditional order from registry");
           conditionalOrders.delete(conditionalOrder);
         }
+        console.log(`Unexpected error while processing order: ${e}`);
       }
     }
   }


### PR DESCRIPTION
Adding an catch all error log in the tenderly actions and making it more clear that placing an order has to happen from the context of the safe that is trying to place the order