### PR TITLE
feat: hash view helper

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -18,6 +18,7 @@ import {
 import type { IConditionalOrder } from "./types/ComposableCoW";
 
 import * as dotenv from "dotenv";
+import { keccak256 } from "ethers/lib/utils";
 dotenv.config();
 
 // These are constant across all networks supported by CoW Protocol
@@ -25,7 +26,7 @@ const RELAYER = "0xC92E8bdf79f0507f65a392b0ab4667716BFE0110";
 const SETTLEMENT = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41";
 
 const TWAP_ORDER_STRUCT =
-  "tuple(address sellToken,address buyToken,address receiver,uint256 partSellAmount,uint256 minPartLimit,uint256 t0,uint256 n,uint256 t,uint256 span)";
+  "tuple(address sellToken,address buyToken,address receiver,uint256 partSellAmount,uint256 minPartLimit,uint256 t0,uint256 n,uint256 t,uint256 span,bytes32 appData)";
 
 const CONDITIONAL_ORDER_PARAMS_STRUCT =
   "tuple(address handler, bytes32 salt, bytes staticInput)";
@@ -41,6 +42,7 @@ interface TWAPData {
   n: number;
   t: number;
   span: number;
+  appData: string;
 }
 
 /**
@@ -296,6 +298,7 @@ async function createTwapOrder(options: TWAPCliOptions) {
     n: options.numParts,
     t: options.timeInterval,
     span: options.span,
+    appData: keccak256("twap.cli"),
   };
 
   const params: IConditionalOrder.ConditionalOrderParamsStruct = {

--- a/script/submit_SingleOrder.s.sol
+++ b/script/submit_SingleOrder.s.sol
@@ -45,7 +45,8 @@ contract SubmitSingleOrder is Script {
             t0: block.timestamp,
             n: 10,
             t: 120,
-            span: 0
+            span: 0,
+            appData: keccak256("forge.scripts.twap")
         });
 
         vm.startBroadcast(deployerPrivateKey);

--- a/src/ComposableCoW.sol
+++ b/src/ComposableCoW.sol
@@ -85,7 +85,7 @@ contract ComposableCoW is ISafeSignatureVerifier {
             revert InvalidHandler();
         }
 
-        singleOrders[msg.sender][keccak256(abi.encode(params))] = true;
+        singleOrders[msg.sender][hash(params)] = true;
         if (dispatch) {
             emit ConditionalOrderCreated(msg.sender, params);
         }
@@ -206,6 +206,17 @@ contract ComposableCoW is ISafeSignatureVerifier {
         }
     }
 
+    // --- helper viewer functions
+
+    /**
+     * Return the hash of the conditional order parameters
+     * @param params `ConditionalOrderParams` for the order
+     * @return hash of the conditional order parameters
+     */
+    function hash(IConditionalOrder.ConditionalOrderParams memory params) public pure returns (bytes32) {
+        return keccak256(abi.encode(params));
+    }
+
     // --- internal functions
 
     /**
@@ -220,12 +231,12 @@ contract ComposableCoW is ISafeSignatureVerifier {
         view
     {
         /// @dev Computing proof using leaf double hashing
-        bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(params))));
+        bytes32 leaf = keccak256(bytes.concat(hash(params)));
         if (!(proof.length == 0 || MerkleProof.verify(proof, roots[owner], leaf))) {
             revert ProofNotAuthed();
         }
 
-        if (!(proof.length != 0 || singleOrders[owner][keccak256(abi.encode(params))])) {
+        if (!(proof.length != 0 || singleOrders[owner][hash(params)])) {
             revert SingleOrderNotAuthed();
         }
     }

--- a/src/types/twap/libraries/TWAPOrder.sol
+++ b/src/types/twap/libraries/TWAPOrder.sol
@@ -38,12 +38,8 @@ library TWAPOrder {
         uint256 n;
         uint256 t;
         uint256 span;
+        bytes32 appData;
     }
-
-    // --- constants
-
-    /// @dev keccak256("conditionalorder.twap")
-    bytes32 private constant APP_DATA = bytes32(0x6a1cb2f57824a1985d4bd2c556f30a048157ee9973efc0a4714604dde0a23104);
 
     // --- functions
 
@@ -82,7 +78,7 @@ library TWAPOrder {
             sellAmount: self.partSellAmount,
             buyAmount: self.minPartLimit,
             validTo: TWAPOrderMathLib.calculateValidTo(self.t0, self.n, self.t, self.span).toUint32(),
-            appData: APP_DATA,
+            appData: self.appData,
             feeAmount: 0,
             kind: GPv2Order.KIND_SELL,
             partiallyFillable: false,

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -166,7 +166,8 @@ contract BaseComposableCoWTest is Base, Merkle {
             t0: block.timestamp,
             n: 2,
             t: 3600,
-            span: 0
+            span: 0,
+            appData: keccak256("test.twap")
         });
 
         // 2. Create n conditional orders as leaves of the ComposableCoW

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -523,7 +523,8 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
             t0: startTime,
             n: NUM_PARTS,
             t: FREQUENCY,
-            span: SPAN
+            span: SPAN,
+            appData: keccak256("test.twap")
         });
     }
 }


### PR DESCRIPTION
This PR:

1. Provides a `H(params)` function on `ComposableCoW`, providing utility for a user to determine the hash from which to cancel their conditional order (if done using a single order).

On merge, this closes #17.