### PR TITLE
fix: StopLoss oracle data checking

### DIFF
--- a/src/BaseConditionalOrder.sol
+++ b/src/BaseConditionalOrder.sol
@@ -12,6 +12,10 @@ import "./interfaces/IConditionalOrder.sol";
  * @author mfw78 <mfw78@rndlabs.xyz>
  */
 abstract contract BaseConditionalOrder is IConditionalOrderGenerator {
+    /// @dev This error is returned by the `verify` function if the *generated* order hash does not match
+    ///      the hash passed as a parameter.
+    error InvalidHash();
+
     /**
      * @inheritdoc IConditionalOrder
      * @dev As an order generator, the `GPv2Order.Data` passed as a parameter is ignored / not validated.
@@ -30,7 +34,7 @@ abstract contract BaseConditionalOrder is IConditionalOrderGenerator {
 
         /// @dev Verify that the *generated* order is valid and matches the payload.
         if (!(_hash == GPv2Order.hash(generatedOrder, domainSeparator))) {
-            revert IConditionalOrder.OrderNotValid();
+            revert IConditionalOrder.OrderNotValid(InvalidHash.selector);
         }
     }
 

--- a/src/BaseConditionalOrder.sol
+++ b/src/BaseConditionalOrder.sol
@@ -5,6 +5,11 @@ import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
 
 import "./interfaces/IConditionalOrder.sol";
 
+// --- error strings
+/// @dev This error is returned by the `verify` function if the *generated* order hash does not match
+///      the hash passed as a parameter.
+string constant INVALID_HASH = "invalid hash";
+
 /**
  * @title Base logic for conditional orders.
  * @dev Enforces the order verification logic for conditional orders, allowing developers
@@ -12,10 +17,6 @@ import "./interfaces/IConditionalOrder.sol";
  * @author mfw78 <mfw78@rndlabs.xyz>
  */
 abstract contract BaseConditionalOrder is IConditionalOrderGenerator {
-    /// @dev This error is returned by the `verify` function if the *generated* order hash does not match
-    ///      the hash passed as a parameter.
-    error InvalidHash();
-
     /**
      * @inheritdoc IConditionalOrder
      * @dev As an order generator, the `GPv2Order.Data` passed as a parameter is ignored / not validated.
@@ -34,7 +35,7 @@ abstract contract BaseConditionalOrder is IConditionalOrderGenerator {
 
         /// @dev Verify that the *generated* order is valid and matches the payload.
         if (!(_hash == GPv2Order.hash(generatedOrder, domainSeparator))) {
-            revert IConditionalOrder.OrderNotValid(InvalidHash.selector);
+            revert IConditionalOrder.OrderNotValid(INVALID_HASH);
         }
     }
 

--- a/src/interfaces/IConditionalOrder.sol
+++ b/src/interfaces/IConditionalOrder.sol
@@ -11,8 +11,8 @@ import {IERC165} from "safe/interfaces/IERC165.sol";
  */
 interface IConditionalOrder {
     /// @dev This error is returned by the `getTradeableOrder` function if the order condition is not met.
-    ///      A parameter of `bytes4` type is included to allow the caller to specify the reason for the failure.
-    error OrderNotValid(bytes4);
+    ///      A parameter of `string` type is included to allow the caller to specify the reason for the failure.
+    error OrderNotValid(string);
 
     /**
      * @dev This struct is used to uniquely identify a conditional order for an owner.

--- a/src/interfaces/IConditionalOrder.sol
+++ b/src/interfaces/IConditionalOrder.sol
@@ -11,7 +11,8 @@ import {IERC165} from "safe/interfaces/IERC165.sol";
  */
 interface IConditionalOrder {
     /// @dev This error is returned by the `getTradeableOrder` function if the order condition is not met.
-    error OrderNotValid();
+    ///      A parameter of `bytes4` type is included to allow the caller to specify the reason for the failure.
+    error OrderNotValid(bytes4);
 
     /**
      * @dev This struct is used to uniquely identify a conditional order for an owner.

--- a/src/types/GoodAfterTime.sol
+++ b/src/types/GoodAfterTime.sol
@@ -8,6 +8,14 @@ import "../vendored/Milkman.sol";
 import "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
+// --- error strings
+/// @dev If the trade is called before the time it becomes valid.
+string constant TOO_EARLY = "too early";
+/// @dev If the sell token balance is below the minimum.
+string constant BALANCE_INSUFFICIENT = "balance insufficient";
+/// @dev If the price checker fails.
+string constant PRICE_CHECKER_FAILED = "price checker failed";
+
 /**
  * @title Good After Time (GAT) Conditional Order - with Milkman price checkers
  * @author mfw78 <mfw78@rndlabs.xyz>
@@ -21,15 +29,6 @@ import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.so
  */
 contract GoodAfterTime is BaseConditionalOrder {
     using SafeCast for uint256;
-
-    // --- errors
-
-    /// @dev If the trade is called before the time it becomes valid.
-    error TooEarly();
-    /// @dev If the sell token balance is below the minimum.
-    error BalanceInsufficient();
-    /// @dev If the price checker fails.
-    error PriceCheckerFailed();
 
     // --- types
 
@@ -64,12 +63,12 @@ contract GoodAfterTime is BaseConditionalOrder {
 
         // Don't allow the order to be placed before it becomes valid.
         if (!(block.timestamp >= data.startTime)) {
-            revert IConditionalOrder.OrderNotValid(TooEarly.selector);
+            revert IConditionalOrder.OrderNotValid(TOO_EARLY);
         }
 
         // Require that the sell token balance is above the minimum.
         if (!(data.sellToken.balanceOf(owner) >= data.minSellBalance)) {
-            revert IConditionalOrder.OrderNotValid(BalanceInsufficient.selector);
+            revert IConditionalOrder.OrderNotValid(BALANCE_INSUFFICIENT);
         }
 
         uint256 buyAmount = abi.decode(offchainInput, (uint256));
@@ -84,7 +83,7 @@ contract GoodAfterTime is BaseConditionalOrder {
 
             // Don't allow the order to be placed if the buyAmount is less than the minimum out.
             if (!(buyAmount >= (_expectedOut * (Utils.MAX_BPS - p.allowedSlippage)) / Utils.MAX_BPS)) {
-                revert IConditionalOrder.OrderNotValid(PriceCheckerFailed.selector);
+                revert IConditionalOrder.OrderNotValid(PRICE_CHECKER_FAILED);
             }
         }
 

--- a/src/types/PerpetualStableSwap.sol
+++ b/src/types/PerpetualStableSwap.sol
@@ -11,6 +11,11 @@ import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.so
  * taking decimals into account (and adding specifiable spread)
  */
 contract PerpetualStableSwap is BaseConditionalOrder {
+    // --- errors
+
+    /// @dev The sell amount is insufficient (ie. not funded).
+    error NotFunded();
+
     /**
      * Creates a new perpetual swap order. All resulting swaps will be made from the target contract.
      * @param tokenA One of the two tokens that can be perpetually swapped against one another
@@ -52,7 +57,7 @@ contract PerpetualStableSwap is BaseConditionalOrder {
 
         // Make sure the order is funded, otherwise it is not valid
         if (!(buySellData.sellAmount > 0)) {
-            revert IConditionalOrder.OrderNotValid();
+            revert IConditionalOrder.OrderNotValid(NotFunded.selector);
         }
 
         // Unless spread is 0 (and there is no surplus), order collision is not an issue as sell and buy amounts should

--- a/src/types/PerpetualStableSwap.sol
+++ b/src/types/PerpetualStableSwap.sol
@@ -6,16 +6,15 @@ import {IERC20, IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.so
 import "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
+// --- error strings
+/// @dev The sell amount is insufficient (ie. not funded).
+string constant NOT_FUNDED = "not funded";
+
 /**
  * @title A smart contract that is always willing to trade between tokenA and tokenB 1:1,
  * taking decimals into account (and adding specifiable spread)
  */
 contract PerpetualStableSwap is BaseConditionalOrder {
-    // --- errors
-
-    /// @dev The sell amount is insufficient (ie. not funded).
-    error NotFunded();
-
     /**
      * Creates a new perpetual swap order. All resulting swaps will be made from the target contract.
      * @param tokenA One of the two tokens that can be perpetually swapped against one another
@@ -57,7 +56,7 @@ contract PerpetualStableSwap is BaseConditionalOrder {
 
         // Make sure the order is funded, otherwise it is not valid
         if (!(buySellData.sellAmount > 0)) {
-            revert IConditionalOrder.OrderNotValid(NotFunded.selector);
+            revert IConditionalOrder.OrderNotValid(NOT_FUNDED);
         }
 
         // Unless spread is 0 (and there is no surplus), order collision is not an issue as sell and buy amounts should

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -64,7 +64,7 @@ contract StopLoss is BaseConditionalOrder {
                 revert IConditionalOrder.OrderNotValid();
             }
 
-            /// @dev Guard against stale data at a user-specified interval. The heartbeat interval should at least exceed the both oracles' update intervals.
+            /// @dev Guard against stale data at a user-specified interval. The maxTimeSinceLastOracleUpdate should at least exceed the both oracles' update intervals.
             if (
                 !(
                     sellUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -56,8 +56,8 @@ contract StopLoss is BaseConditionalOrder {
         Data memory data = abi.decode(staticInput, (Data));
         // scope variables to avoid stack too deep error
         {
-            (, int256 basePrice,,uint256 sellUpdatedAt,) = data.sellTokenPriceOracle.latestRoundData();
-            (, int256 quotePrice,,uint256 buyUpdatedAt,) = data.buyTokenPriceOracle.latestRoundData();
+            (, int256 basePrice,, uint256 sellUpdatedAt,) = data.sellTokenPriceOracle.latestRoundData();
+            (, int256 quotePrice,, uint256 buyUpdatedAt,) = data.buyTokenPriceOracle.latestRoundData();
 
             /// @dev Guard against invalid price data
             if (!(basePrice > 0 && quotePrice > 0)) {
@@ -65,7 +65,12 @@ contract StopLoss is BaseConditionalOrder {
             }
 
             /// @dev Guard against stale data at a user-specified interval. The heartbeat interval should at least exceed the both oracles' update intervals.
-            if(!(sellUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate && buyUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate)) {
+            if (
+                !(
+                    sellUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate
+                        && buyUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate
+                )
+            ) {
                 revert IConditionalOrder.OrderNotValid();
             }
 
@@ -105,11 +110,7 @@ contract StopLoss is BaseConditionalOrder {
      * @param oracleDecimals the decimals the oracle returns
      * @param erc20Decimals the decimals of the erc20 token
      */
-    function scalePrice(
-        int256 oraclePrice,
-        uint8 oracleDecimals,
-        uint8 erc20Decimals
-    ) internal pure returns (int256) {
+    function scalePrice(int256 oraclePrice, uint8 oracleDecimals, uint8 erc20Decimals) internal pure returns (int256) {
         if (oracleDecimals < erc20Decimals) {
             return oraclePrice * int256(10 ** uint256(erc20Decimals - oracleDecimals));
         } else if (oracleDecimals > erc20Decimals) {

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -15,6 +15,15 @@ import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.so
  * @dev This order type does not have any replay protection, meaning it may trigger again in the next validityBucket (e.g. 00:15-00:30)
  */
 contract StopLoss is BaseConditionalOrder {
+    // --- errors
+
+    /// @dev Invalid price data returned by the oracle
+    error OracleInvalidPrice();
+    /// @dev The oracle has returned stale data
+    error OracleStalePrice();
+    /// @dev The strike price has not been reached
+    error StrikeNotReached();
+
     /**
      * Defines the parameters of a StopLoss order
      * @param sellToken: the token to be sold
@@ -61,7 +70,7 @@ contract StopLoss is BaseConditionalOrder {
 
             /// @dev Guard against invalid price data
             if (!(basePrice > 0 && quotePrice > 0)) {
-                revert IConditionalOrder.OrderNotValid();
+                revert IConditionalOrder.OrderNotValid(OracleInvalidPrice.selector);
             }
 
             /// @dev Guard against stale data at a user-specified interval. The maxTimeSinceLastOracleUpdate should at least exceed the both oracles' update intervals.
@@ -71,7 +80,7 @@ contract StopLoss is BaseConditionalOrder {
                         && buyUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate
                 )
             ) {
-                revert IConditionalOrder.OrderNotValid();
+                revert IConditionalOrder.OrderNotValid(OracleStalePrice.selector);
             }
 
             uint8 oracleSellTokenDecimals = data.sellTokenPriceOracle.decimals();
@@ -84,7 +93,7 @@ contract StopLoss is BaseConditionalOrder {
             quotePrice = scalePrice(quotePrice, oracleBuyTokenDecimals, erc20BuyTokenDecimals);
 
             if (!(basePrice / quotePrice <= data.strike)) {
-                revert IConditionalOrder.OrderNotValid();
+                revert IConditionalOrder.OrderNotValid(StrikeNotReached.selector);
             }
         }
 

--- a/src/types/TradeAboveThreshold.sol
+++ b/src/types/TradeAboveThreshold.sol
@@ -10,6 +10,11 @@ import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.so
  * @title A smart contract that trades whenever its balance of a certain token exceeds a target threshold
  */
 contract TradeAboveThreshold is BaseConditionalOrder {
+    // --- errors
+
+    /// @dev The sell token balance is below the threshold (ie. threshold not met).
+    error BalanceInsufficient();
+
     struct Data {
         IERC20 sellToken;
         IERC20 buyToken;
@@ -36,7 +41,7 @@ contract TradeAboveThreshold is BaseConditionalOrder {
         uint256 balance = data.sellToken.balanceOf(owner);
         // Don't allow the order to be placed if the balance is less than the threshold.
         if (!(balance >= data.threshold)) {
-            revert IConditionalOrder.OrderNotValid();
+            revert IConditionalOrder.OrderNotValid(BalanceInsufficient.selector);
         }
         // ensures that orders queried shortly after one another result in the same hash (to avoid spamming the orderbook)
         order = GPv2Order.Data(

--- a/src/types/TradeAboveThreshold.sol
+++ b/src/types/TradeAboveThreshold.sol
@@ -6,15 +6,15 @@ import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
 import "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
+// --- error strings
+
+/// @dev The sell token balance is below the threshold (ie. threshold not met).
+string constant BALANCE_INSUFFICIENT = "balance insufficient";
+
 /**
  * @title A smart contract that trades whenever its balance of a certain token exceeds a target threshold
  */
 contract TradeAboveThreshold is BaseConditionalOrder {
-    // --- errors
-
-    /// @dev The sell token balance is below the threshold (ie. threshold not met).
-    error BalanceInsufficient();
-
     struct Data {
         IERC20 sellToken;
         IERC20 buyToken;
@@ -41,7 +41,7 @@ contract TradeAboveThreshold is BaseConditionalOrder {
         uint256 balance = data.sellToken.balanceOf(owner);
         // Don't allow the order to be placed if the balance is less than the threshold.
         if (!(balance >= data.threshold)) {
-            revert IConditionalOrder.OrderNotValid(BalanceInsufficient.selector);
+            revert IConditionalOrder.OrderNotValid(BALANCE_INSUFFICIENT);
         }
         // ensures that orders queried shortly after one another result in the same hash (to avoid spamming the orderbook)
         order = GPv2Order.Data(

--- a/src/types/twap/TWAP.sol
+++ b/src/types/twap/TWAP.sol
@@ -17,6 +17,11 @@ import {TWAPOrder} from "./libraries/TWAPOrder.sol";
 contract TWAP is BaseConditionalOrder {
     ComposableCoW public immutable composableCow;
 
+    // --- errors
+
+    /// @dev The order is not within the TWAP bundle's span.
+    error NotWithinSpan();
+
     constructor(ComposableCoW _composableCow) {
         composableCow = _composableCow;
     }
@@ -51,7 +56,7 @@ contract TWAP is BaseConditionalOrder {
 
         /// @dev Revert if the order is outside the TWAP bundle's span.
         if (!(block.timestamp <= order.validTo)) {
-            revert IConditionalOrder.OrderNotValid();
+            revert IConditionalOrder.OrderNotValid(NotWithinSpan.selector);
         }
     }
 }

--- a/src/types/twap/TWAP.sol
+++ b/src/types/twap/TWAP.sol
@@ -6,6 +6,11 @@ import "../../ComposableCoW.sol";
 import "../../BaseConditionalOrder.sol";
 import {TWAPOrder} from "./libraries/TWAPOrder.sol";
 
+// --- error strings
+
+/// @dev The order is not within the TWAP bundle's span.
+string constant NOT_WITHIN_SPAN = "not within span";
+
 /**
  * @title TWAP Conditional Order
  * @author mfw78 <mfw78@rndlabs.xyz>
@@ -16,11 +21,6 @@ import {TWAPOrder} from "./libraries/TWAPOrder.sol";
  */
 contract TWAP is BaseConditionalOrder {
     ComposableCoW public immutable composableCow;
-
-    // --- errors
-
-    /// @dev The order is not within the TWAP bundle's span.
-    error NotWithinSpan();
 
     constructor(ComposableCoW _composableCow) {
         composableCow = _composableCow;
@@ -56,7 +56,7 @@ contract TWAP is BaseConditionalOrder {
 
         /// @dev Revert if the order is outside the TWAP bundle's span.
         if (!(block.timestamp <= order.validTo)) {
-            revert IConditionalOrder.OrderNotValid(NotWithinSpan.selector);
+            revert IConditionalOrder.OrderNotValid(NOT_WITHIN_SPAN);
         }
     }
 }

--- a/src/types/twap/libraries/TWAPOrder.sol
+++ b/src/types/twap/libraries/TWAPOrder.sol
@@ -5,7 +5,19 @@ import {IERC20, IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.so
 import {SafeCast} from "@openzeppelin/utils/math/SafeCast.sol";
 import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
 
+import {IConditionalOrder} from "../../../interfaces/IConditionalOrder.sol";
 import {TWAPOrderMathLib} from "./TWAPOrderMathLib.sol";
+
+// --- error strings
+
+string constant INVALID_SAME_TOKEN = "same token";
+string constant INVALID_TOKEN = "invalid token";
+string constant INVALID_PART_SELL_AMOUNT = "invalid part sell amount";
+string constant INVALID_MIN_PART_LIMIT = "invalid min part limit";
+string constant INVALID_START_TIME = "invalid start time";
+string constant INVALID_NUM_PARTS = "invalid num parts";
+string constant INVALID_FREQUENCY = "invalid frequency";
+string constant INVALID_SPAN = "invalid span";
 
 /**
  * @title Time-weighted Average Order Library
@@ -14,17 +26,6 @@ import {TWAPOrderMathLib} from "./TWAPOrderMathLib.sol";
  */
 library TWAPOrder {
     using SafeCast for uint256;
-
-    // --- errors
-
-    error InvalidSameToken();
-    error InvalidToken();
-    error InvalidPartSellAmount();
-    error InvalidMinPartLimit();
-    error InvalidStartTime();
-    error InvalidNumParts();
-    error InvalidFrequency();
-    error InvalidSpan();
 
     // --- structs
 
@@ -48,14 +49,14 @@ library TWAPOrder {
      * @param self The TWAP order to validate
      */
     function validate(Data memory self) internal pure {
-        if (!(self.sellToken != self.buyToken)) revert InvalidSameToken();
-        if (!(address(self.sellToken) != address(0) && address(self.buyToken) != address(0))) revert InvalidToken();
-        if (!(self.partSellAmount > 0)) revert InvalidPartSellAmount();
-        if (!(self.minPartLimit > 0)) revert InvalidMinPartLimit();
-        if (!(self.t0 < type(uint32).max)) revert InvalidStartTime();
-        if (!(self.n > 1 && self.n <= type(uint32).max)) revert InvalidNumParts();
-        if (!(self.t > 0 && self.t <= 365 days)) revert InvalidFrequency();
-        if (!(self.span <= self.t)) revert InvalidSpan();
+        if (!(self.sellToken != self.buyToken)) revert IConditionalOrder.OrderNotValid(INVALID_SAME_TOKEN);
+        if (!(address(self.sellToken) != address(0) && address(self.buyToken) != address(0))) revert IConditionalOrder.OrderNotValid(INVALID_TOKEN);
+        if (!(self.partSellAmount > 0)) revert IConditionalOrder.OrderNotValid(INVALID_PART_SELL_AMOUNT);
+        if (!(self.minPartLimit > 0)) revert IConditionalOrder.OrderNotValid(INVALID_MIN_PART_LIMIT);
+        if (!(self.t0 < type(uint32).max)) revert IConditionalOrder.OrderNotValid(INVALID_START_TIME);
+        if (!(self.n > 1 && self.n <= type(uint32).max)) revert IConditionalOrder.OrderNotValid(INVALID_NUM_PARTS);
+        if (!(self.t > 0 && self.t <= 365 days)) revert IConditionalOrder.OrderNotValid(INVALID_FREQUENCY);
+        if (!(self.span <= self.t)) revert IConditionalOrder.OrderNotValid(INVALID_SPAN);
     }
 
     /**

--- a/src/types/twap/libraries/TWAPOrder.sol
+++ b/src/types/twap/libraries/TWAPOrder.sol
@@ -50,7 +50,9 @@ library TWAPOrder {
      */
     function validate(Data memory self) internal pure {
         if (!(self.sellToken != self.buyToken)) revert IConditionalOrder.OrderNotValid(INVALID_SAME_TOKEN);
-        if (!(address(self.sellToken) != address(0) && address(self.buyToken) != address(0))) revert IConditionalOrder.OrderNotValid(INVALID_TOKEN);
+        if (!(address(self.sellToken) != address(0) && address(self.buyToken) != address(0))) {
+            revert IConditionalOrder.OrderNotValid(INVALID_TOKEN);
+        }
         if (!(self.partSellAmount > 0)) revert IConditionalOrder.OrderNotValid(INVALID_PART_SELL_AMOUNT);
         if (!(self.minPartLimit > 0)) revert IConditionalOrder.OrderNotValid(INVALID_MIN_PART_LIMIT);
         if (!(self.t0 < type(uint32).max)) revert IConditionalOrder.OrderNotValid(INVALID_START_TIME);

--- a/src/types/twap/libraries/TWAPOrderMathLib.sol
+++ b/src/types/twap/libraries/TWAPOrderMathLib.sol
@@ -3,19 +3,19 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {IConditionalOrder} from "../../../interfaces/IConditionalOrder.sol";
 
+// --- error strings
+
+/// @dev No discrete order is valid before the start of the TWAP conditional order.
+string constant BEFORE_TWAP_START = "before twap start";
+/// @dev No discrete order is valid after it's last part.
+string constant AFTER_TWAP_FINISH = "after twap finish";
+
 /**
  * @title CoWProtocol TWAP Order Math Library
  * @dev TWAP Math is separated to facilitate easier unit testing / SMT verification.
  * @author mfw78 <mfw78@rndlabs.xyz>
  */
 library TWAPOrderMathLib {
-    // --- errors
-
-    /// @dev No discrete order is valid before the start of the TWAP conditional order.
-    error BeforeTWAPStart();
-    /// @dev No discrete order is valid after it's last part.
-    error AfterTWAPFinish();
-
     /**
      * @dev Calculate the `validTo` timestamp for part of a TWAP order.
      * @param startTime The start time of the TWAP order.
@@ -39,7 +39,7 @@ library TWAPOrderMathLib {
 
         unchecked {
             /// @dev Order is not valid before the start (order commences at `t0`).
-            if (!(startTime <= block.timestamp)) revert IConditionalOrder.OrderNotValid(BeforeTWAPStart.selector);
+            if (!(startTime <= block.timestamp)) revert IConditionalOrder.OrderNotValid(BEFORE_TWAP_START);
 
             /**
              *  @dev Order is expired after the last part (`n` parts, running at `t` time length).
@@ -51,7 +51,7 @@ library TWAPOrderMathLib {
              * `type(uint32).max` so the sum of `startTime + (numParts * frequency)` is ≈ 2⁵⁵.
              */
             if (!(block.timestamp < startTime + (numParts * frequency))) {
-                revert IConditionalOrder.OrderNotValid(AfterTWAPFinish.selector);
+                revert IConditionalOrder.OrderNotValid(AFTER_TWAP_FINISH);
             }
 
             /**

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -14,7 +14,7 @@ import {TestAccount, TestAccountLib} from "./libraries/TestAccountLib.t.sol";
 import {SafeLib} from "./libraries/SafeLib.t.sol";
 import {ComposableCoWLib} from "./libraries/ComposableCoWLib.t.sol";
 
-import {BaseConditionalOrder} from "../src/BaseConditionalOrder.sol";
+import "../src/BaseConditionalOrder.sol";
 import {BaseSwapGuard} from "../src/guards/BaseSwapGuard.sol";
 
 import {TWAP, TWAPOrder} from "../src/types/twap/TWAP.sol";

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -40,7 +40,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
 
         // should revert when the current time is before the start time
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.TooEarly.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TOO_EARLY)
         );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
@@ -63,7 +63,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
 
         // should revert when the current balance is below the minimum balance
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.BalanceInsufficient.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BALANCE_INSUFFICIENT)
         );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
@@ -95,7 +95,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         deal(address(o.sellToken), address(safe1), o.minSellBalance);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.PriceCheckerFailed.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, PRICE_CHECKER_FAILED)
         );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(buyAmount));
     }

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -39,7 +39,9 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // should revert when the current time is before the start time
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.TooEarly.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.TooEarly.selector)
+        );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -60,7 +62,9 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         deal(address(o.sellToken), address(safe1), currentBalance);
 
         // should revert when the current balance is below the minimum balance
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.BalanceInsufficient.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.BalanceInsufficient.selector)
+        );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -90,7 +94,9 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // set the current balance
         deal(address(o.sellToken), address(safe1), o.minSellBalance);
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.PriceCheckerFailed.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.PriceCheckerFailed.selector)
+        );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(buyAmount));
     }
 

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -39,9 +39,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // should revert when the current time is before the start time
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TOO_EARLY)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TOO_EARLY));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -62,9 +60,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         deal(address(o.sellToken), address(safe1), currentBalance);
 
         // should revert when the current balance is below the minimum balance
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BALANCE_INSUFFICIENT)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BALANCE_INSUFFICIENT));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -94,9 +90,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // set the current balance
         deal(address(o.sellToken), address(safe1), o.minSellBalance);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, PRICE_CHECKER_FAILED)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, PRICE_CHECKER_FAILED));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(buyAmount));
     }
 

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -39,7 +39,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // should revert when the current time is before the start time
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.TooEarly.selector));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -60,7 +60,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         deal(address(o.sellToken), address(safe1), currentBalance);
 
         // should revert when the current balance is below the minimum balance
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.BalanceInsufficient.selector));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -90,7 +90,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // set the current balance
         deal(address(o.sellToken), address(safe1), o.minSellBalance);
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, GoodAfterTime.PriceCheckerFailed.selector));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(buyAmount));
     }
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -65,9 +65,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
 
         createOrder(stopLoss, 0x0, abi.encode(data));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -102,9 +100,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: staleTime
         });
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -205,9 +201,11 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         assertEq(order.buyTokenBalance, GPv2Order.BALANCE_ERC20);
     }
 
-    function test_OracleRevertOnStalePrice_fuzz(uint256 currentTime, uint256 maxTimeSinceLastOracleUpdate, uint256 updatedAt)
-        public
-    {
+    function test_OracleRevertOnStalePrice_fuzz(
+        uint256 currentTime,
+        uint256 maxTimeSinceLastOracleUpdate,
+        uint256 updatedAt
+    ) public {
         // guard against underflow
         vm.assume(currentTime > maxTimeSinceLastOracleUpdate);
         vm.assume(currentTime < type(uint32).max);
@@ -232,9 +230,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: maxTimeSinceLastOracleUpdate
         });
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_STALE_PRICE)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_STALE_PRICE));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -263,9 +259,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
 
         // case where buy token price is invalid
@@ -273,9 +267,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         data.sellTokenPriceOracle = mockOracle(SELL_ORACLE, validPrice, block.timestamp, DEFAULT_DECIMALS);
         data.buyTokenPriceOracle = mockOracle(BUY_ORACLE, invalidPrice, block.timestamp, DEFAULT_DECIMALS);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -29,7 +29,10 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         return address(uint160(int160(price)));
     }
 
-    function mockOracle(address mock, int256 price, uint256 updatedAt, uint8 decimals) internal returns (IAggregatorV3Interface iface) {
+    function mockOracle(address mock, int256 price, uint256 updatedAt, uint8 decimals)
+        internal
+        returns (IAggregatorV3Interface iface)
+    {
         iface = IAggregatorV3Interface(mock);
         vm.mockCall(mock, abi.encodeWithSelector(iface.latestRoundData.selector), abi.encode(0, price, 0, updatedAt, 0));
         vm.mockCall(mock, abi.encodeWithSelector(iface.decimals.selector), abi.encode(decimals));
@@ -66,9 +69,13 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
-    function test_RevertStrikePriceNotMet_fuzz(int256 sellTokenOraclePrice, int256 buyTokenOraclePrice, int256 strike, uint256 currentTime, uint256 staleTime)
-        public
-    {
+    function test_RevertStrikePriceNotMet_fuzz(
+        int256 sellTokenOraclePrice,
+        int256 buyTokenOraclePrice,
+        int256 strike,
+        uint256 currentTime,
+        uint256 staleTime
+    ) public {
         vm.assume(buyTokenOraclePrice > 0);
         vm.assume(sellTokenOraclePrice > 0);
         vm.assume(strike > 0);
@@ -97,8 +104,12 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
-
-    function test_OracleNormalisesPrice_fuzz(uint8 sellTokenERC20Decimals, uint8 buyTokenERC20Decimals, uint8 sellTokenOracleDecimals, uint8 buyTokenOracleDecimals) public {
+    function test_OracleNormalisesPrice_fuzz(
+        uint8 sellTokenERC20Decimals,
+        uint8 buyTokenERC20Decimals,
+        uint8 sellTokenOracleDecimals,
+        uint8 buyTokenOracleDecimals
+    ) public {
         // guard against overflow.
         // given the use of the decimals in exponentiation, supporting type(uint8).max
         // is not possible as the result of the exponentiation would overflow uint256.
@@ -114,9 +125,20 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         StopLoss.Data memory data = StopLoss.Data({
             sellToken: mockToken(SELL_TOKEN, sellTokenERC20Decimals),
             buyToken: mockToken(BUY_TOKEN, buyTokenERC20Decimals),
-            sellTokenPriceOracle: mockOracle(SELL_ORACLE, int256(1834 * (10**sellTokenOracleDecimals)), block.timestamp, sellTokenOracleDecimals),
-            buyTokenPriceOracle: mockOracle(BUY_ORACLE, int256(1 * (10**buyTokenOracleDecimals)), block.timestamp, buyTokenOracleDecimals),
-            strike: int256(1900 * (sellTokenERC20Decimals > buyTokenERC20Decimals ? (10**(sellTokenERC20Decimals - buyTokenERC20Decimals)) : (10**(buyTokenERC20Decimals - sellTokenERC20Decimals)))), // Strike price is atomic units, base / quote. ie. 1900_000_000_000_000_000_000 / 1_000_000 = 1900 USDC/ETH
+            sellTokenPriceOracle: mockOracle(
+                SELL_ORACLE, int256(1834 * (10 ** sellTokenOracleDecimals)), block.timestamp, sellTokenOracleDecimals
+                ),
+            buyTokenPriceOracle: mockOracle(
+                BUY_ORACLE, int256(1 * (10 ** buyTokenOracleDecimals)), block.timestamp, buyTokenOracleDecimals
+                ),
+            strike: int256(
+                1900
+                    * (
+                        sellTokenERC20Decimals > buyTokenERC20Decimals
+                            ? (10 ** (sellTokenERC20Decimals - buyTokenERC20Decimals))
+                            : (10 ** (buyTokenERC20Decimals - sellTokenERC20Decimals))
+                    )
+                ), // Strike price is atomic units, base / quote. ie. 1900_000_000_000_000_000_000 / 1_000_000 = 1900 USDC/ETH
             sellAmount: 1 ether,
             buyAmount: 1,
             appData: APP_DATA,
@@ -179,7 +201,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         assertEq(order.buyTokenBalance, GPv2Order.BALANCE_ERC20);
     }
 
-    function test_OracleRevertOnStalePrice_fuzz(uint256 currentTime, uint256 heartBeatInterval, uint256 updatedAt) public {
+    function test_OracleRevertOnStalePrice_fuzz(uint256 currentTime, uint256 heartBeatInterval, uint256 updatedAt)
+        public
+    {
         // guard against underflow
         vm.assume(currentTime > heartBeatInterval);
         vm.assume(currentTime < type(uint32).max);

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -57,7 +57,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            heartBeatInterval: 15 minutes
+            maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
         createOrder(stopLoss, 0x0, abi.encode(data));
@@ -90,7 +90,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            heartBeatInterval: staleTime
+            maxTimeSinceLastOracleUpdate: staleTime
         });
 
         vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
@@ -114,7 +114,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: true,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            heartBeatInterval: 15 minutes
+            maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
         GPv2Order.Data memory order =
@@ -155,7 +155,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            heartBeatInterval: heartBeatInterval
+            maxTimeSinceLastOracleUpdate: heartBeatInterval
         });
 
         vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
@@ -184,7 +184,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            heartBeatInterval: 15 minutes
+            maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
         vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
@@ -221,7 +221,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            heartBeatInterval: 15 minutes
+            maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
         GPv2Order.Data memory order =
@@ -256,7 +256,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 1 hours,
-            heartBeatInterval: 15 minutes
+            maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
         // 25 June 2023 18:59:59

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -65,7 +65,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
 
         createOrder(stopLoss, 0x0, abi.encode(data));
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector)
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -100,7 +102,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: staleTime
         });
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector)
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -228,7 +232,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: maxTimeSinceLastOracleUpdate
         });
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleStalePrice.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleStalePrice.selector)
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -257,7 +263,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector)
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
 
         // case where buy token price is invalid
@@ -265,7 +273,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         data.sellTokenPriceOracle = mockOracle(SELL_ORACLE, validPrice, block.timestamp, DEFAULT_DECIMALS);
         data.buyTokenPriceOracle = mockOracle(BUY_ORACLE, invalidPrice, block.timestamp, DEFAULT_DECIMALS);
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector)
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -65,7 +65,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
 
         createOrder(stopLoss, 0x0, abi.encode(data));
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -100,7 +100,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: staleTime
         });
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -228,7 +228,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: maxTimeSinceLastOracleUpdate
         });
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleStalePrice.selector));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -257,7 +257,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
 
         // case where buy token price is invalid
@@ -265,7 +265,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         data.sellTokenPriceOracle = mockOracle(SELL_ORACLE, validPrice, block.timestamp, DEFAULT_DECIMALS);
         data.buyTokenPriceOracle = mockOracle(BUY_ORACLE, invalidPrice, block.timestamp, DEFAULT_DECIMALS);
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector));
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -201,14 +201,14 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         assertEq(order.buyTokenBalance, GPv2Order.BALANCE_ERC20);
     }
 
-    function test_OracleRevertOnStalePrice_fuzz(uint256 currentTime, uint256 heartBeatInterval, uint256 updatedAt)
+    function test_OracleRevertOnStalePrice_fuzz(uint256 currentTime, uint256 maxTimeSinceLastOracleUpdate, uint256 updatedAt)
         public
     {
         // guard against underflow
-        vm.assume(currentTime > heartBeatInterval);
+        vm.assume(currentTime > maxTimeSinceLastOracleUpdate);
         vm.assume(currentTime < type(uint32).max);
         // enforce stale price
-        vm.assume(updatedAt < (currentTime - heartBeatInterval));
+        vm.assume(updatedAt < (currentTime - maxTimeSinceLastOracleUpdate));
 
         vm.warp(currentTime);
 
@@ -225,7 +225,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             isSellOrder: false,
             isPartiallyFillable: false,
             validityBucketSeconds: 15 minutes,
-            maxTimeSinceLastOracleUpdate: heartBeatInterval
+            maxTimeSinceLastOracleUpdate: maxTimeSinceLastOracleUpdate
         });
 
         vm.expectRevert(IConditionalOrder.OrderNotValid.selector);

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -66,7 +66,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         createOrder(stopLoss, 0x0, abi.encode(data));
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED)
         );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
@@ -103,7 +103,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         });
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.StrikeNotReached.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED)
         );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
@@ -233,7 +233,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         });
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleStalePrice.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_STALE_PRICE)
         );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
@@ -264,7 +264,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         });
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE)
         );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
 
@@ -274,7 +274,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         data.buyTokenPriceOracle = mockOracle(BUY_ORACLE, invalidPrice, block.timestamp, DEFAULT_DECIMALS);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, StopLoss.OracleInvalidPrice.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE)
         );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -235,7 +235,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         bytes32 domainSeparator = composableCow.domainSeparator();
 
         // should revert as the order hash mismatches
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BaseConditionalOrder.InvalidHash.selector));
         composableCow.isValidSafeSignature(
             Safe(payable(address(alice.addr))),
             address(0),

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -236,7 +236,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should revert as the order hash mismatches
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BaseConditionalOrder.InvalidHash.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_HASH)
         );
         composableCow.isValidSafeSignature(
             Safe(payable(address(alice.addr))),

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -235,9 +235,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         bytes32 domainSeparator = composableCow.domainSeparator();
 
         // should revert as the order hash mismatches
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_HASH)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_HASH));
         composableCow.isValidSafeSignature(
             Safe(payable(address(alice.addr))),
             address(0),

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -235,7 +235,9 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         bytes32 domainSeparator = composableCow.domainSeparator();
 
         // should revert as the order hash mismatches
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BaseConditionalOrder.InvalidHash.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BaseConditionalOrder.InvalidHash.selector)
+        );
         composableCow.isValidSafeSignature(
             Safe(payable(address(alice.addr))),
             address(0),

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -7,6 +7,7 @@ import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
 import "./ComposableCoW.base.t.sol";
 
 import "../src/types/twap/TWAP.sol";
+import "../src/types/twap/libraries/TWAPOrder.sol";
 import "../src/types/twap/libraries/TWAPOrderMathLib.sol";
 
 import "../src/value_factories/CurrentBlockTimestampFactory.sol";
@@ -54,7 +55,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         o.sellToken = token0;
         o.buyToken = token0;
 
-        vm.expectRevert(TWAPOrder.InvalidSameToken.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_SAME_TOKEN)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -66,13 +69,17 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.sellToken = IERC20(address(0));
 
-        vm.expectRevert(TWAPOrder.InvalidToken.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_TOKEN)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
 
         o.sellToken = token0;
         o.buyToken = IERC20(address(0));
 
-        vm.expectRevert(TWAPOrder.InvalidToken.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_TOKEN)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -84,7 +91,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.partSellAmount = 0;
 
-        vm.expectRevert(TWAPOrder.InvalidPartSellAmount.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_PART_SELL_AMOUNT)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -96,7 +105,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.minPartLimit = 0;
 
-        vm.expectRevert(TWAPOrder.InvalidMinPartLimit.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_MIN_PART_LIMIT)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -109,7 +120,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(startTime);
         o.t0 = startTime;
 
-        vm.expectRevert(TWAPOrder.InvalidStartTime.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_START_TIME)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -122,7 +135,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.n = numParts;
 
-        vm.expectRevert(TWAPOrder.InvalidNumParts.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_NUM_PARTS)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -134,7 +149,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.t = frequency;
 
-        vm.expectRevert(TWAPOrder.InvalidFrequency.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_FREQUENCY)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -149,7 +166,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         o.t = frequency;
         o.span = span;
 
-        vm.expectRevert(TWAPOrder.InvalidSpan.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_SPAN)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -7,7 +7,7 @@ import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
 import "./ComposableCoW.base.t.sol";
 
 import "../src/types/twap/TWAP.sol";
-import {TWAPOrderMathLib} from "../src/types/twap/libraries/TWAPOrderMathLib.sol";
+import "../src/types/twap/libraries/TWAPOrderMathLib.sol";
 
 import "../src/value_factories/CurrentBlockTimestampFactory.sol";
 
@@ -175,7 +175,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BEFORE_TWAP_START)
         );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
@@ -202,7 +202,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, AFTER_TWAP_FINISH)
         );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
@@ -231,7 +231,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to outside of the span
         vm.warp(currentTime);
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAP.NotWithinSpan.selector));
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, NOT_WITHIN_SPAN));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -261,7 +261,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
 
         // The below should revert
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BEFORE_TWAP_START)
         );
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
@@ -292,7 +292,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
 
         // The below should revert
         vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector)
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, AFTER_TWAP_FINISH)
         );
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -55,9 +55,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         o.sellToken = token0;
         o.buyToken = token0;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_SAME_TOKEN)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_SAME_TOKEN));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -69,17 +67,13 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.sellToken = IERC20(address(0));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_TOKEN)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_TOKEN));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
 
         o.sellToken = token0;
         o.buyToken = IERC20(address(0));
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_TOKEN)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_TOKEN));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -91,9 +85,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.partSellAmount = 0;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_PART_SELL_AMOUNT)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_PART_SELL_AMOUNT));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -105,9 +97,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.minPartLimit = 0;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_MIN_PART_LIMIT)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_MIN_PART_LIMIT));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -120,9 +110,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(startTime);
         o.t0 = startTime;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_START_TIME)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_START_TIME));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -135,9 +123,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.n = numParts;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_NUM_PARTS)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_NUM_PARTS));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -149,9 +135,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
         o.t = frequency;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_FREQUENCY)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_FREQUENCY));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -166,9 +150,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         o.t = frequency;
         o.span = span;
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_SPAN)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, INVALID_SPAN));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -193,9 +175,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to current time
         vm.warp(currentTime);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BEFORE_TWAP_START)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BEFORE_TWAP_START));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -220,9 +200,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to expiry
         vm.warp(currentTime);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, AFTER_TWAP_FINISH)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, AFTER_TWAP_FINISH));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -279,9 +257,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BEFORE_TWAP_START)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BEFORE_TWAP_START));
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
 
@@ -310,9 +286,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, AFTER_TWAP_FINISH)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, AFTER_TWAP_FINISH));
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
 

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -174,7 +174,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to current time
         vm.warp(currentTime);
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -199,7 +199,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to expiry
         vm.warp(currentTime);
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -227,7 +227,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to outside of the span
         vm.warp(currentTime);
 
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAP.NotWithinSpan.selector));
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -256,7 +256,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector));
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
 
@@ -285,7 +285,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(IConditionalOrder.OrderNotValid.selector);
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector));
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
 

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -174,7 +174,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to current time
         vm.warp(currentTime);
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -199,7 +201,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to expiry
         vm.warp(currentTime);
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector)
+        );
         twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
     }
 
@@ -256,7 +260,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.BeforeTWAPStart.selector)
+        );
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
 
@@ -285,7 +291,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TWAPOrderMathLib.AfterTWAPFinish.selector)
+        );
         composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
     }
 


### PR DESCRIPTION
This PR addresses checking of the oracle data, such that:

1. Oracle price sanity (greater than 0) is checked.
2. Oracle price staleness (via configurable parameter in `Data` struct).
3. Normalises the prices when comparing with the strike.

Closes #30 