### PR TITLE
fix: ackee oracle price normalisation

### DIFF
--- a/src/types/ConditionalOrdersUtilsLib.sol
+++ b/src/types/ConditionalOrdersUtilsLib.sol
@@ -15,4 +15,19 @@ library ConditionalOrdersUtilsLib {
     function validToBucket(uint32 validity) internal view returns (uint32 validTo) {
         validTo = ((uint32(block.timestamp) / validity) * validity) + validity;
     }
+
+    /**
+     * Given a price returned by a chainlink-like oracle, scale it to the desired amount of decimals
+     * @param oraclePrice return by a chainlink-like oracle
+     * @param fromDecimals the decimals the oracle returned (e.g. 8 for USDC)
+     * @param toDecimals the amount of decimals the price should be scaled to
+     */
+    function scalePrice(int256 oraclePrice, uint8 fromDecimals, uint8 toDecimals) internal pure returns (int256) {
+        if (fromDecimals < toDecimals) {
+            return oraclePrice * int256(10 ** uint256(toDecimals - fromDecimals));
+        } else if (fromDecimals > toDecimals) {
+            return oraclePrice / int256(10 ** uint256(fromDecimals - toDecimals));
+        }
+        return oraclePrice;
+    }
 }

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.sol";
 
 import "../BaseConditionalOrder.sol";
 import "../interfaces/IAggregatorV3Interface.sol";

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -112,5 +112,4 @@ contract StopLoss is BaseConditionalOrder {
             GPv2Order.BALANCE_ERC20
         );
     }
-
 }

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -77,9 +77,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         uint256 staleTime
     ) public {
         vm.assume(buyTokenOraclePrice > 0);
-        vm.assume(sellTokenOraclePrice > 0);
+        vm.assume(sellTokenOraclePrice > 0 && sellTokenOraclePrice <= type(int256).max / 10 ** 18);
         vm.assume(strike > 0);
-        vm.assume(sellTokenOraclePrice / buyTokenOraclePrice > strike);
+        vm.assume(sellTokenOraclePrice * int256(10 ** 18) / buyTokenOraclePrice > strike);
         vm.assume(currentTime > staleTime);
 
         vm.warp(currentTime);
@@ -135,10 +135,10 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
                 1900
                     * (
                         sellTokenERC20Decimals > buyTokenERC20Decimals
-                            ? (10 ** (sellTokenERC20Decimals - buyTokenERC20Decimals))
-                            : (10 ** (buyTokenERC20Decimals - sellTokenERC20Decimals))
+                            ? (10 ** (sellTokenERC20Decimals - buyTokenERC20Decimals + 18))
+                            : (10 ** (buyTokenERC20Decimals - sellTokenERC20Decimals + 18))
                     )
-                ), // Strike price is atomic units, base / quote. ie. 1900_000_000_000_000_000_000 / 1_000_000 = 1900 USDC/ETH
+                ), // Strike price is to 18 decimals, base / quote. ie. 1900_000_000_000_000_000_000 = 1900 USDC/ETH
             sellAmount: 1 ether,
             buyAmount: 1,
             appData: APP_DATA,
@@ -174,7 +174,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             buyToken: mockToken(BUY_TOKEN, 6), // simulate USDC (using the USDC/USD chainlink)
             sellTokenPriceOracle: mockOracle(SELL_ORACLE, 183_449_235_095, block.timestamp, 8), // assume price is 1834.49235095 ETH/USD
             buyTokenPriceOracle: mockOracle(BUY_ORACLE, 100_000_000, block.timestamp, 8), // assume 1:1 USDC:USD
-            strike: 1900_000_000_000_000, // Strike price is atomic units, base / quote. ie. 1900_000_000_000_000_000_000 / 1_000_000 = 1900 USDC/ETH
+            strike: 1900_000_000_000_000_000_000, // Strike price is base / quote to 18 decimals. ie. 1900_000_000_000_000_000_000 = 1900 USDC/ETH
             sellAmount: 1 ether,
             buyAmount: 1,
             appData: APP_DATA,
@@ -273,9 +273,9 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
 
     function test_strikePriceMet_fuzz(int256 sellTokenOraclePrice, int256 buyTokenOraclePrice, int256 strike) public {
         vm.assume(buyTokenOraclePrice > 0);
-        vm.assume(sellTokenOraclePrice > 0);
+        vm.assume(sellTokenOraclePrice > 0 && sellTokenOraclePrice <= type(int256).max / 10 ** 18);
         vm.assume(strike > 0);
-        vm.assume(sellTokenOraclePrice / buyTokenOraclePrice <= strike);
+        vm.assume(sellTokenOraclePrice * int256(10 ** 18) / buyTokenOraclePrice <= strike);
 
         // 25 June 2023 18:40:51
         vm.warp(1687718451);
@@ -320,7 +320,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             buyToken: mockToken(BUY_TOKEN, 18),
             sellTokenPriceOracle: mockOracle(SELL_ORACLE, 99 ether, BLOCK_TIMESTAMP, DEFAULT_DECIMALS),
             buyTokenPriceOracle: mockOracle(BUY_ORACLE, 100 ether, BLOCK_TIMESTAMP, DEFAULT_DECIMALS),
-            strike: 1,
+            strike: 1e18, // required as the strike price has 18 decimals
             sellAmount: 1 ether,
             buyAmount: 1 ether,
             appData: APP_DATA,


### PR DESCRIPTION
This PR:

1. Removes any notion of the ERC20 decimal being used for price comparison, and instead relies on a strike price with 18 decimal places.
2. Moves the scalePrice function to util libs as this may be useful across future oracle-related endeavours.