### PR TITLE
Add draft for custom twap order type with increasing minPartLimit for each part

### DIFF
--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -27,7 +27,7 @@ string constant INVALID_TOKEN = "invalid token";
 string constant INVALID_PART_SELL_AMOUNT = "invalid part sell amount";
 /// @dev The minimum buy amount in each part (limit) is not gretater than zero.
 string constant INVALID_MIN_PART_LIMIT = "invalid min part limit";
-/// @dev The valid until time is 
+/// @dev The valid until time is invalid.
 string constant INVALID_VALID_TO_TIME = "invalid valid until time";
 
 /// @title BatchLimitSell Conditional Order
@@ -76,7 +76,7 @@ contract BatchLimitSell is BaseConditionalOrder {
 
         _validate(data); 
 
-        // Get the sell price for the part
+        // Get the min part limit for the part
         uint256 minPartLimit = _getMinPartLimit(data);
 
         if (!(minPartLimit > 0)) revert IConditionalOrder.OrderNotValid(INVALID_MIN_PART_LIMIT);
@@ -118,7 +118,7 @@ contract BatchLimitSell is BaseConditionalOrder {
         return uint256(wadPow(int256(base), int256(exponent)));
     }
 
-    /// @dev Compute the sell price for a given part index in a TWAP order.
+    /// @dev Compute the minimum buy amount in each part (limit).
     /// @param data The TWAP order data containing startPrice, endPrice, n (total parts), and current part index.
     /// @return minPartLimit The calculated minimum buy amount in each part (limit).
     function _getMinPartLimit(Data memory data) internal pure returns (uint256 minPartLimit) {
@@ -126,7 +126,7 @@ contract BatchLimitSell is BaseConditionalOrder {
             return data.startPrice;
         }
 
-        uint256 incrementFactor = 1e18 + (data.percentageIncrease * 1e16); // Convert % to WAD (e.g., 5% = 1.05e18)
+        uint256 incrementFactor = 1e18 + (data.percentageIncrease * 1e16);
         uint256 exponent = (data.part - 1) * 1e18 / (data.n - 1);
         minPartLimit = (data.startPrice * _pow(incrementFactor, exponent)) / 1e18;
     }

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -15,8 +15,6 @@ import {wadPow} from "../vendored/SignedWadMath.sol";
 
 // --- error strings
 
-/// @dev The order count is not > 1.
-string constant INVALID_ORDER_COUNT = "invalid order count";
 /// @dev The part id is not > 0 and <= n or total number of parts.
 string constant PART_NUMBER_OUT_OF_RANGE = "part number out of range";
 /// @dev Invalid number of total number of parts, i.e., not greater than 1 and <= type(uint32).max.
@@ -100,6 +98,7 @@ contract BatchLimitSell is BaseConditionalOrder {
      * @param data The TWAP order to validate
      */
     function _validate(Data memory data) internal view {
+        if (!(data.part > 0 && data.part <= data.n)) revert IConditionalOrder.OrderNotValid(PART_NUMBER_OUT_OF_RANGE);
         if (!(data.sellToken != data.buyToken)) revert IConditionalOrder.OrderNotValid(INVALID_SAME_TOKEN);
         if (!(address(data.sellToken) != address(0) && address(data.buyToken) != address(0))) {
             revert IConditionalOrder.OrderNotValid(INVALID_TOKEN);
@@ -121,9 +120,6 @@ contract BatchLimitSell is BaseConditionalOrder {
     /// @param data The TWAP order data containing startPrice, endPrice, n (total parts), and current part index.
     /// @return sellPrice The calculated sell price for the given part.
     function _getSellPrice(Data memory data) internal pure returns (uint256 sellPrice) {
-        if (!(data.part > 0 && data.part <= data.n)) revert IConditionalOrder.OrderNotValid(PART_NUMBER_OUT_OF_RANGE);
-        if (!(data.n > 1 && data.n <= type(uint32).max)) revert IConditionalOrder.OrderNotValid(INVALID_NUM_PARTS);
-
         if (data.part == 1) {
             return data.startPrice;
         }

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -27,6 +27,8 @@ string constant INVALID_PART_SELL_AMOUNT = "invalid part sell amount";
 string constant INVALID_MIN_PART_LIMIT = "invalid min part limit";
 /// @dev The valid until time is invalid.
 string constant INVALID_VALID_TO_TIME = "invalid valid until time";
+/// @dev The percentage increase is zero.
+string constant INVALID_PERCENTAGE_INCREASE = "invalid percentage increase";
 
 /// @title BatchLimitSell Conditional Order
 /// @notice A custom order type for the CoW Protocol Conditional Order Framework.
@@ -107,6 +109,7 @@ contract BatchLimitSell is BaseConditionalOrder {
         }
         if (!(data.partSellAmount > 0)) revert IConditionalOrder.OrderNotValid(INVALID_PART_SELL_AMOUNT);
         if (!(data.validTo > block.timestamp && data.validTo <= 365 days)) revert IConditionalOrder.OrderNotValid(INVALID_VALID_TO_TIME);
+        if (!(data.percentageIncrease > 0)) revert IConditionalOrder.OrderNotValid(INVALID_PERCENTAGE_INCREASE);
     }
 
     /// @dev Power function to calculate the increment factor.
@@ -124,7 +127,6 @@ contract BatchLimitSell is BaseConditionalOrder {
         if (data.part == 1) {
             return data.startPrice;
         }
-
         uint256 incrementFactor = 1e18 + (data.percentageIncrease * 1e16);
         uint256 exponent = (data.part - 1) * 1e18 / (data.n - 1);
         minPartLimit = (data.startPrice * _pow(incrementFactor, exponent)) / 1e18;

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -124,9 +124,8 @@ contract BatchLimitSell is BaseConditionalOrder {
             return data.startPrice;
         }
 
-        uint256 incrementFactor = 1e18 + (data.percentageIncrease * 1e16); // Convert % to WAD (5% = 1.05e18)
+        uint256 incrementFactor = 1e18 + (data.percentageIncrease * 1e16); // Convert % to WAD (e.g., 5% = 1.05e18)
         uint256 exponent = (data.part - 1) * 1e18 / (data.n - 1);
         minPartLimit = (data.startPrice * _pow(incrementFactor, exponent)) / 1e18;
     }
-
 }

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -17,8 +17,6 @@ import {wadPow} from "../vendored/SignedWadMath.sol";
 
 /// @dev The part id is not > 0 and <= n or total number of parts.
 string constant PART_NUMBER_OUT_OF_RANGE = "part number out of range";
-/// @dev Invalid number of total number of parts, i.e., not greater than 1 and <= type(uint32).max.
-string constant INVALID_NUM_PARTS = "invalid num parts";
 /// @dev The sell token and buy token are the same.
 string constant INVALID_SAME_TOKEN = "same token";
 /// @dev The sell token and buy token addresses should both not be address(0).
@@ -100,14 +98,15 @@ contract BatchLimitSell is BaseConditionalOrder {
     /// @dev revert if the order is invalid
     /// @param data The TWAP order to validate
     function _validate(Data memory data) internal view {
-        if (!(data.part > 0 && data.part <= data.n)) revert IConditionalOrder.OrderNotValid(PART_NUMBER_OUT_OF_RANGE);
+        if (!(data.n > 1 && data.n <= type(uint32).max && data.part > 0 && data.part <= data.n)) {
+            revert IConditionalOrder.OrderNotValid(PART_NUMBER_OUT_OF_RANGE);
+        }
         if (!(data.sellToken != data.buyToken)) revert IConditionalOrder.OrderNotValid(INVALID_SAME_TOKEN);
         if (!(address(data.sellToken) != address(0) && address(data.buyToken) != address(0))) {
             revert IConditionalOrder.OrderNotValid(INVALID_TOKEN);
         }
         if (!(data.partSellAmount > 0)) revert IConditionalOrder.OrderNotValid(INVALID_PART_SELL_AMOUNT);
         if (!(data.validTo > block.timestamp && data.validTo <= 365 days)) revert IConditionalOrder.OrderNotValid(INVALID_VALID_TO_TIME);
-        if (!(data.n > 1 && data.n <= type(uint32).max)) revert IConditionalOrder.OrderNotValid(INVALID_NUM_PARTS);
     }
 
     /// @dev Power function to calculate the increment factor.

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -30,6 +30,10 @@ string constant INVALID_MIN_PART_LIMIT = "invalid min part limit";
 /// @dev The valid until time is 
 string constant INVALID_VALID_TO_TIME = "invalid valid until time";
 
+/// @title BatchLimitSell Conditional Order
+/// @notice A custom order type for the CoW Protocol Conditional Order Framework.
+/// @dev This order allows placing a batch limit sell order, where each part in the batch 
+///      is sold at a price incremented by a fixed percentage relative to the previous part.
 contract BatchLimitSell is BaseConditionalOrder {
     // --- types
 

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -32,7 +32,7 @@ string constant INVALID_MIN_PART_LIMIT = "invalid min part limit";
 /// @dev The valid until time is 
 string constant INVALID_VALID_TO_TIME = "invalid valid until time";
 
-contract TWAPWithIncreasingMinPartLimit is BaseConditionalOrder {
+contract BatchLimitSell is BaseConditionalOrder {
     // --- types
 
     struct Data {

--- a/src/types/BatchLimitSell.sol
+++ b/src/types/BatchLimitSell.sol
@@ -93,10 +93,8 @@ contract BatchLimitSell is BaseConditionalOrder {
         });
     }
     
-    /**
-     * @dev revert if the order is invalid
-     * @param data The TWAP order to validate
-     */
+    /// @dev revert if the order is invalid
+    /// @param data The TWAP order to validate
     function _validate(Data memory data) internal view {
         if (!(data.part > 0 && data.part <= data.n)) revert IConditionalOrder.OrderNotValid(PART_NUMBER_OUT_OF_RANGE);
         if (!(data.sellToken != data.buyToken)) revert IConditionalOrder.OrderNotValid(INVALID_SAME_TOKEN);

--- a/src/types/TWAPWithIncreasingMinPartLimit.sol
+++ b/src/types/TWAPWithIncreasingMinPartLimit.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {ComposableCoW} from "../ComposableCoW.sol";
+
+import {
+    IERC20,
+    IConditionalOrder,
+    IConditionalOrderGenerator,
+    GPv2Order,
+    BaseConditionalOrder
+} from "../BaseConditionalOrder.sol";
+import {TWAPOrder} from "./twap/libraries/TWAPOrder.sol";
+
+// --- error strings
+
+/// @dev The order is not within the TWAP bundle's span.
+string constant NOT_WITHIN_SPAN = "not within span";
+/// @dev The order count is not > 1.
+string constant INVALID_ORDER_COUNT = "invalid order count";
+/// @dev The part id is not > 0 and <= n or total number of parts.
+string constant PART_NUMBER_OUT_OF_RANGE = "part number out of range";
+/// @dev Invalid number of total number of parts, i.e., not greater than 1 and <= type(uint32).max.
+string constant INVALID_NUM_PARTS = "invalid num parts";
+
+contract TWAPWithIncreasingMinPartLimit is BaseConditionalOrder {
+    // --- types
+
+    struct Data {
+        IERC20 sellToken; // The token being sold
+        IERC20 buyToken; // The token being bought
+        address receiver; // The order owner (user who initiated the order)
+        uint256 partSellAmount; // The amount to sell in each part
+        uint256 startPrice; // Sell price for the first part
+        uint256 endPrice; // Sell price for the last part
+        uint256 t0; // Start timestamp
+        uint256 t; // Time interval for each part
+        uint256 n; // Number of parts
+        uint256 part; // Part number or identifier from 1...n
+        uint256 span; // Time span of interval t for each part
+        bytes32 appData; // Application-specific data
+    }
+
+    ComposableCoW public immutable composableCow;
+
+    constructor(ComposableCoW _composableCow) {
+        composableCow = _composableCow;
+    }
+
+    /// @inheritdoc IConditionalOrderGenerator
+    /// @dev `owner`, `sender` and `offchainInput` is not used.
+    function getTradeableOrder(address owner, address, bytes32 ctx, bytes calldata staticInput, bytes calldata)
+        public
+        view
+        override
+        returns (GPv2Order.Data memory order)
+    {
+        // Decode the payload into the twap with increasing minPartLimit parameters.
+        Data memory data = abi.decode(staticInput, (Data));
+
+        // Get the sell price for the part
+        uint256 sellPrice = _getSellPrice(data);
+
+        // Set up the TWAPData for order generation
+        TWAPOrder.Data memory twap = TWAPOrder.Data({
+            sellToken: data.sellToken,
+            buyToken: data.buyToken,
+            receiver: data.receiver,
+            partSellAmount: data.partSellAmount,
+            minPartLimit: sellPrice, // Replace minPartLimit with the computed sellPrice for the specific part
+            t0: data.t0,
+            n: data.n,
+            t: data.t,
+            span: data.span,
+            appData: data.appData
+        });
+
+        // Validate part and generate GPv2Order data for the part
+        /// @dev If `twap.t0` is set to 0, then get the start time from the context.
+        if (twap.t0 == 0) {
+            twap.t0 = uint256(composableCow.cabinet(owner, ctx));
+        }
+
+        order = TWAPOrder.orderFor(twap);
+
+        /// @dev Revert if the order is outside the TWAP bundle's span.
+        if (!(block.timestamp <= order.validTo)) {
+            revert IConditionalOrder.OrderNotValid(NOT_WITHIN_SPAN);
+        }
+    }
+
+    /// @dev Calculate the increment factor to increase the price.
+    /// i.e., incrementFactor = (endPrice / startPrice) ^ (1 / (n - 1))
+    /// @param startPrice The starting price.
+    /// @param endPrice The ending price.
+    /// @param orderCount The number of orders.
+    /// @return incrementFactor The factor by which the price will increase between orders.
+    function _getIncrementFactor(uint256 startPrice, uint256 endPrice, uint256 orderCount)
+        internal
+        pure
+        returns (uint256)
+    {
+        if (!(orderCount > 1)) {
+            revert IConditionalOrder.OrderNotValid(INVALID_ORDER_COUNT);
+        }
+
+        uint256 fraction = (endPrice * 1e18) / startPrice;
+        return _pow(fraction, 1e18 / (orderCount - 1));
+    }
+
+    /// @dev Power function to calculate the increment factor.
+    /// @param base The base to be raised to the power.
+    /// @param exponent The exponent to raise the base to.
+    /// @return result The result of raising the base to the exponent.
+    function _pow(uint256 base, uint256 exponent) internal pure returns (uint256) {
+        uint256 result = 1e18;
+        while (exponent > 0) {
+            if (exponent % 2 == 1) {
+                result = (result * base) / 1e18;
+            }
+            base = (base * base) / 1e18;
+            exponent /= 2;
+        }
+        return result;
+    }
+
+    /// @dev Compute the sell price for a given part index in a TWAP order.
+    /// @param data The TWAP order data containing startPrice, endPrice, n (total parts), and current part index.
+    /// @return sellPrice The calculated sell price for the given part.
+    function _getSellPrice(Data memory data) internal pure returns (uint256 sellPrice) {
+        if (!(data.part > 0 && data.part <= data.n)) revert IConditionalOrder.OrderNotValid(PART_NUMBER_OUT_OF_RANGE);
+        if (!(data.n > 1 && data.n <= type(uint32).max)) revert IConditionalOrder.OrderNotValid(INVALID_NUM_PARTS);
+
+        // Avoid overflow when exponent is small
+        if (data.part == 1) {
+            return data.startPrice;
+        }
+
+        // Calculate the incremental factor
+        uint256 incrementFactor = _getIncrementFactor(data.startPrice, data.endPrice, data.n);
+
+        // Calculate the sell price for the given part using exponential growth formula
+        // i.e., incrementFactor^(part-1), multiplied by startPrice
+        uint256 exponent = ((data.part - 1) * 1e18) / (data.n - 1);
+        sellPrice = (data.startPrice * _pow(incrementFactor, exponent)) / 1e18;
+    }
+}

--- a/src/vendored/SignedWadMath.sol
+++ b/src/vendored/SignedWadMath.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+// Vendored from Solmate with unused functions removed
+// Source code: https://github.com/transmissions11/solmate/blob/main/src/utils/SignedWadMath.sol
+/// @notice Signed 18 decimal fixed point (wad) arithmetic library.
+
+/// @dev Will not work with negative bases, only use when x is positive.
+function wadPow(int256 x, int256 y) pure returns (int256) {
+    // Equivalent to x to the power of y because x ** y = (e ** ln(x)) ** y = e ** (ln(x) * y)
+    return wadExp((wadLn(x) * y) / 1e18); // Using ln(x) means x must be greater than 0.
+}
+
+function wadExp(int256 x) pure returns (int256 r) {
+    unchecked {
+        // When the result is < 0.5 we return zero. This happens when
+        // x <= floor(log(0.5e18) * 1e18) ~ -42e18
+        if (x <= -42139678854452767551) return 0;
+
+        // When the result is > (2**255 - 1) / 1e18 we can not represent it as an
+        // int. This happens when x >= floor(log((2**255 - 1) / 1e18) * 1e18) ~ 135.
+        if (x >= 135305999368893231589) revert("EXP_OVERFLOW");
+
+        // x is now in the range (-42, 136) * 1e18. Convert to (-42, 136) * 2**96
+        // for more intermediate precision and a binary basis. This base conversion
+        // is a multiplication by 1e18 / 2**96 = 5**18 / 2**78.
+        x = (x << 78) / 5**18;
+
+        // Reduce range of x to (-½ ln 2, ½ ln 2) * 2**96 by factoring out powers
+        // of two such that exp(x) = exp(x') * 2**k, where k is an integer.
+        // Solving this gives k = round(x / log(2)) and x' = x - k * log(2).
+        int256 k = ((x << 96) / 54916777467707473351141471128 + 2**95) >> 96;
+        x = x - k * 54916777467707473351141471128;
+
+        // k is in the range [-61, 195].
+
+        // Evaluate using a (6, 7)-term rational approximation.
+        // p is made monic, we'll multiply by a scale factor later.
+        int256 y = x + 1346386616545796478920950773328;
+        y = ((y * x) >> 96) + 57155421227552351082224309758442;
+        int256 p = y + x - 94201549194550492254356042504812;
+        p = ((p * y) >> 96) + 28719021644029726153956944680412240;
+        p = p * x + (4385272521454847904659076985693276 << 96);
+
+        // We leave p in 2**192 basis so we don't need to scale it back up for the division.
+        int256 q = x - 2855989394907223263936484059900;
+        q = ((q * x) >> 96) + 50020603652535783019961831881945;
+        q = ((q * x) >> 96) - 533845033583426703283633433725380;
+        q = ((q * x) >> 96) + 3604857256930695427073651918091429;
+        q = ((q * x) >> 96) - 14423608567350463180887372962807573;
+        q = ((q * x) >> 96) + 26449188498355588339934803723976023;
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Div in assembly because solidity adds a zero check despite the unchecked.
+            // The q polynomial won't have zeros in the domain as all its roots are complex.
+            // No scaling is necessary because p is already 2**96 too large.
+            r := sdiv(p, q)
+        }
+
+        // r should be in the range (0.09, 0.25) * 2**96.
+
+        // We now need to multiply r by:
+        // * the scale factor s = ~6.031367120.
+        // * the 2**k factor from the range reduction.
+        // * the 1e18 / 2**96 factor for base conversion.
+        // We do this all at once, with an intermediate result in 2**213
+        // basis, so the final right shift is always by a positive amount.
+        r = int256((uint256(r) * 3822833074963236453042738258902158003155416615667) >> uint256(195 - k));
+    }
+}
+
+function wadLn(int256 x) pure returns (int256 r) {
+    unchecked {
+        require(x > 0, "UNDEFINED");
+
+        // We want to convert x from 10**18 fixed point to 2**96 fixed point.
+        // We do this by multiplying by 2**96 / 10**18. But since
+        // ln(x * C) = ln(x) + ln(C), we can simply do nothing here
+        // and add ln(2**96 / 10**18) at the end.
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
+            r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            r := or(r, shl(3, lt(0xff, shr(r, x))))
+            r := or(r, shl(2, lt(0xf, shr(r, x))))
+            r := or(r, shl(1, lt(0x3, shr(r, x))))
+            r := or(r, lt(0x1, shr(r, x)))
+        }
+
+        // Reduce range of x to (1, 2) * 2**96
+        // ln(2^k * x) = k * ln(2) + ln(x)
+        int256 k = r - 96;
+        x <<= uint256(159 - k);
+        x = int256(uint256(x) >> 159);
+
+        // Evaluate using a (8, 8)-term rational approximation.
+        // p is made monic, we will multiply by a scale factor later.
+        int256 p = x + 3273285459638523848632254066296;
+        p = ((p * x) >> 96) + 24828157081833163892658089445524;
+        p = ((p * x) >> 96) + 43456485725739037958740375743393;
+        p = ((p * x) >> 96) - 11111509109440967052023855526967;
+        p = ((p * x) >> 96) - 45023709667254063763336534515857;
+        p = ((p * x) >> 96) - 14706773417378608786704636184526;
+        p = p * x - (795164235651350426258249787498 << 96);
+
+        // We leave p in 2**192 basis so we don't need to scale it back up for the division.
+        // q is monic by convention.
+        int256 q = x + 5573035233440673466300451813936;
+        q = ((q * x) >> 96) + 71694874799317883764090561454958;
+        q = ((q * x) >> 96) + 283447036172924575727196451306956;
+        q = ((q * x) >> 96) + 401686690394027663651624208769553;
+        q = ((q * x) >> 96) + 204048457590392012362485061816622;
+        q = ((q * x) >> 96) + 31853899698501571402653359427138;
+        q = ((q * x) >> 96) + 909429971244387300277376558375;
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Div in assembly because solidity adds a zero check despite the unchecked.
+            // The q polynomial is known not to have zeros in the domain.
+            // No scaling required because p is already 2**96 too large.
+            r := sdiv(p, q)
+        }
+
+        // r is in the range (0, 0.125) * 2**96
+
+        // Finalization, we need to:
+        // * multiply by the scale factor s = 5.549…
+        // * add ln(2**96 / 10**18)
+        // * add k * ln(2)
+        // * multiply by 10**18 / 2**96 = 5**18 >> 78
+
+        // mul s * 5e18 * 2**96, base is now 5**18 * 2**192
+        r *= 1677202110996718588342820967067443963516166;
+        // add ln(2) * k * 5e18 * 2**192
+        r += 16597577552685614221487285958193947469193820559219878177908093499208371 * k;
+        // add ln(2**96 / 10**18) * 5e18 * 2**192
+        r += 600920179829731861736702779321621459595472258049074101567377883020018308;
+        // base conversion: mul 2**18 / 2**192
+        r >>= 174;
+    }
+}


### PR DESCRIPTION
# Description
Based on a [feedback](https://x.com/tatsugitsune/status/1897399822266851764) received for limit orders. The feedback is as follows:
```Create a feature that allows a user to generate multiple limit orders with one signed statement, where each limit order buys or sells the same number of tokens in 1% increments. 

For example, create 50 sell limit orders from price A up to price B, with X number of tokens, and ensure that each iteration is 1% higher than the previous limit order. Divide the tokens equally across a price range.

This will allow users to efficiently dollar cost average in and out of a market without having to sign 50 messages.
```

## Changes

This PR introduces a draft smart contract, `TWAPWithIncreasingMinPartLimit.sol`, located in `src/types`.

The contract implements a custom TWAP (Time-Weighted Average Price) limit order where:

1. The percentage increment and minimum buy amount for each part are dynamically calculated.

2. These calculations use the specified start and end prices of the TWAP.

3. A unique order identifier determines the specific TWAP part for which a conditional order is generated.

4. This enables automated, structured execution of TWAP orders with increasing limits over time.

## How to test
