### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - main
     paths-ignore:
       - "**/*.md"
 
@@ -27,7 +25,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.2.3
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
# Description

As seen in #101, CI has started [failing](https://github.com/cowprotocol/composable-cow/actions/runs/15610526816) on the latest Foundry nightly.

Earliest known failing version:

```
forge Version: 1.2.3-nightly
Commit SHA: 6fb7c5983ab0333006aa40a792c24357c49a92cf
Build Timestamp: 2025-06-13T06:02:48.236521304Z (1749794568)
Build Profile: maxperf
```

# Changes

- Pin CI to use Foundry stable v1.2.3.
- Always run CI on push events (it makes it easier to check for CI errors before creating a PR).

## How to test

See CI execution.