### PR TITLE
chore: use Etherscan API V2 for contract verification

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,13 +19,12 @@ timeout = 100000
 verbosity = 3
 
 # Contract verification via the Etherscan API V2.
-# The legacy per-explorer V1 endpoints (e.g. api.gnosisscan.io) are deprecated; V2 uses a single
-# host with the chain id as a query parameter, and one etherscan.io API key works across all chains.
+# The legacy per-explorer V1 endpoints (e.g. api.gnosisscan.io) are deprecated. 
 # Set ETHERSCAN_API_KEY to a key from https://etherscan.io/myapikey
 [etherscan]
-mainnet = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=1" }
-gnosis = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=100" }
-sepolia = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=11155111" }
-arbitrum = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=42161" }
-bnb = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=56" }
-linea = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=59144" }
+mainnet = { key = "${ETHERSCAN_API_KEY}" }
+gnosis = { key = "${ETHERSCAN_API_KEY}" }
+sepolia = { key = "${ETHERSCAN_API_KEY}" }
+arbitrum = { key = "${ETHERSCAN_API_KEY}" }
+bnb = { key = "${ETHERSCAN_API_KEY}" }
+linea = { key = "${ETHERSCAN_API_KEY}" }

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,13 +18,13 @@ timeout = 100000
 [profile.ci]
 verbosity = 3
 
-# Contract verification via the Etherscan API V2.
-# The legacy per-explorer V1 endpoints (e.g. api.gnosisscan.io) are deprecated. 
-# Set ETHERSCAN_API_KEY to a key from https://etherscan.io/myapikey
+# Contract verification via the Etherscan API V2 (per-explorer V1 endpoints are deprecated).
+# Explicit `url`/`chain` are needed so `forge script --verify` uses V2 too, not just `forge verify-contract`.
+# Requires ETHERSCAN_API_KEY from https://etherscan.io/myapikey.
 [etherscan]
-mainnet = { key = "${ETHERSCAN_API_KEY}" }
-gnosis = { key = "${ETHERSCAN_API_KEY}" }
-sepolia = { key = "${ETHERSCAN_API_KEY}" }
-arbitrum = { key = "${ETHERSCAN_API_KEY}" }
-bnb = { key = "${ETHERSCAN_API_KEY}" }
-linea = { key = "${ETHERSCAN_API_KEY}" }
+mainnet = { key = "${ETHERSCAN_API_KEY}", chain = 1, url = "https://api.etherscan.io/v2/api" }
+gnosis = { key = "${ETHERSCAN_API_KEY}", chain = 100, url = "https://api.etherscan.io/v2/api" }
+sepolia = { key = "${ETHERSCAN_API_KEY}", chain = 11155111, url = "https://api.etherscan.io/v2/api" }
+arbitrum = { key = "${ETHERSCAN_API_KEY}", chain = 42161, url = "https://api.etherscan.io/v2/api" }
+bnb = { key = "${ETHERSCAN_API_KEY}", chain = 56, url = "https://api.etherscan.io/v2/api" }
+linea = { key = "${ETHERSCAN_API_KEY}", chain = 59144, url = "https://api.etherscan.io/v2/api" }

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,3 +17,15 @@ timeout = 100000
 
 [profile.ci]
 verbosity = 3
+
+# Contract verification via the Etherscan API V2.
+# The legacy per-explorer V1 endpoints (e.g. api.gnosisscan.io) are deprecated; V2 uses a single
+# host with the chain id as a query parameter, and one etherscan.io API key works across all chains.
+# Set ETHERSCAN_API_KEY to a key from https://etherscan.io/myapikey
+[etherscan]
+mainnet = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=1" }
+gnosis = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=100" }
+sepolia = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=11155111" }
+arbitrum = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=42161" }
+bnb = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=56" }
+linea = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/v2/api?chainid=59144" }


### PR DESCRIPTION
## What

Verification was broken when I tried to deploy a contract. This is because this used Etherscan v1 which has been shut down.

This adds **Etherscan API V2** for all supported chains (mainnet, gnosis, sepolia, arbitrum, bnb, linea).

## Test plan

Set the api key env.

```bash
export ETHERSCAN_API_KEY=<your etherscan.io key>
```

Test by verifying the already verified TWAP contract for all networks:

```bash
for chain in mainnet gnosis sepolia arbitrum bsc linea; do
  echo "=== $chain ==="
  forge verify-contract 0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5 \
    src/types/twap/TWAP.sol:TWAP \
    --chain "$chain" \
    --constructor-args 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74 \
    --watch
done
```

NOtE: Constructor arg is the `ComposableCoW` address was obtained like this:
```
cast abi-encode "constructor(address)" 0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74

# 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74
```


✅ You should get an output similar to this:
```
=== mainnet ===
Start verifying contract `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5` deployed on mainnet
Constructor args: 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74

Contract [src/types/twap/TWAP.sol:TWAP] "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5" is already verified. Skipping verification.
=== gnosis ===
Start verifying contract `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5` deployed on xdai
Constructor args: 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74

Contract [src/types/twap/TWAP.sol:TWAP] "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5" is already verified. Skipping verification.
=== sepolia ===
Start verifying contract `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5` deployed on sepolia
Constructor args: 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74

Contract [src/types/twap/TWAP.sol:TWAP] "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5" is already verified. Skipping verification.
=== arbitrum ===
Start verifying contract `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5` deployed on arbitrum
Constructor args: 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74

Contract [src/types/twap/TWAP.sol:TWAP] "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5" is already verified. Skipping verification.
=== bsc ===
Start verifying contract `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5` deployed on bsc
Constructor args: 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74

Contract [src/types/twap/TWAP.sol:TWAP] "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5" is already verified. Skipping verification.
=== linea ===
Start verifying contract `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5` deployed on linea
Constructor args: 0x000000000000000000000000fdafc9d1902f4e0b84f65f49f244b32b31013b74

Contract [src/types/twap/TWAP.sol:TWAP] "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5" is already verified. Skipping verification.
```